### PR TITLE
No use of suffix in api with new scheme

### DIFF
--- a/app/lib/Auth.js
+++ b/app/lib/Auth.js
@@ -14,7 +14,6 @@ function signup(params) {
       path: path.join(
         config.api.prefix,
         config.api.version,
-        config.api.suffix,
         config.api.user
       )
     }, params)
@@ -30,7 +29,6 @@ function authenticate(params) {
       path: path.join(
         config.api.prefix,
         config.api.version,
-        config.api.suffix,
         config.api.auth
       )
     }, params)
@@ -46,7 +44,6 @@ function refreshAccessToken(params) {
       path: path.join(
         config.api.prefix,
         config.api.version,
-        config.api.suffix,
         config.api.tokens
       )
     }, params)

--- a/development.yaml
+++ b/development.yaml
@@ -5,7 +5,6 @@ frontend:
 api:
   prefix: api
   version: v1
-  suffix: api
   hostname: localhost
   port: 6543
   auth: authentications

--- a/production.yaml
+++ b/production.yaml
@@ -5,7 +5,6 @@ frontend:
 api:
   prefix: api
   version: v1
-  suffix: api
   hostname: localhost
   port: 6543
   auth: authentications


### PR DESCRIPTION
I do all merge on api side and there is no more suffix for api routes (use of route_prefix pyramid configuration common to all loaded components).