### PR TITLE
HTTP repsonse 200 should be considered valid

### DIFF
--- a/app/lib/api.js
+++ b/app/lib/api.js
@@ -30,7 +30,7 @@ function query(params) {
     });
 
     res.on('end', function endCallback() {
-      if (res && res.statusCode > 200 && res.statusCode < 300) {
+      if (res && res.statusCode >= 200 && res.statusCode < 300) {
         !options.success || options.success(data);
       } else {
         !options.error || options.error(


### PR DESCRIPTION
While looking at the code, I might be wrong, but it seems 200 status from proxyfied API are considered an error status.

Anyway, it feels bad to not render the whole request. What about piping directly to express response? I found https://stackoverflow.com/questions/10435407/proxy-with-express-js that can give some insight about the way to go. WDYT?